### PR TITLE
Fix error on windows while trying to import nightwatch conf file.

### DIFF
--- a/src/NightwatchExt/core.ts
+++ b/src/NightwatchExt/core.ts
@@ -255,7 +255,7 @@ export class NightwatchExt {
       if (
         (document && editor.document === document) ||
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ===
-          this.extContext.workspace
+        this.extContext.workspace
       ) {
         this.triggerUpdateActiveEditor(editor);
       }
@@ -392,9 +392,9 @@ export class NightwatchExt {
       .findFiles('**/*nightwatch*.conf.{js,ts,cjs}', undefined, 1)
       .then(async (res) => {
         delete __non_webpack_require__.cache[
-          __non_webpack_require__.resolve(res[0].path)
+          __non_webpack_require__.resolve(res[0].fsPath)
         ];
-        const nwConfig = require(/* webpackIgnore: true */ res[0].path);
+        const nwConfig = require(/* webpackIgnore: true */ res[0].fsPath);
         const workspaceState = this.context.workspaceState;
         workspaceState.update('nwConfig', nwConfig);
         this.environmentsPanel._addNwEnvironments();

--- a/src/extensionManager.ts
+++ b/src/extensionManager.ts
@@ -61,9 +61,9 @@ export class ExtensionManager {
       .findFiles('**/*nightwatch*.conf.{js,ts,cjs}', undefined, 1)
       .then((res) => {
         delete __non_webpack_require__.cache[
-          __non_webpack_require__.resolve(res[0].path)
+          __non_webpack_require__.resolve(res[0].fsPath)
         ];
-        const nwConfig = require(/* webpackIgnore: true */ res[0].path);
+        const nwConfig = require(/* webpackIgnore: true */ res[0].fsPath);
         const workspaceState = this.context.workspaceState;
         workspaceState.update('nwConfig', nwConfig);
       });
@@ -125,7 +125,7 @@ export class ExtensionManager {
     const vscode = this._vscode;
     const workspace =
       vscode.workspace.workspaceFolders &&
-      vscode.workspace.workspaceFolders.length <= 1
+        vscode.workspace.workspaceFolders.length <= 1
         ? vscode.workspace.workspaceFolders[0]
         : await vscode.window.showWorkspaceFolderPick();
 


### PR DESCRIPTION
Fixes: #39 

While `require`ing files, we should use the `fsPath` property of URI instead of `path` because `path` property contains wrongly formatted file path for Windows which results in an error: https://stackoverflow.com/a/76337375/9890886